### PR TITLE
Stop extend String class, use to_str instead

### DIFF
--- a/lib/circleci/env/command/apply_command.rb
+++ b/lib/circleci/env/command/apply_command.rb
@@ -37,7 +37,7 @@ module Circleci
 
             add_envvars.each do |envvar|
               puts "  + add    #{envvar.name}=#{envvar.value}".light_green
-              api.add_envvar(proj.id, envvar.name, envvar.value.raw) unless dry_run?
+              api.add_envvar(proj.id, envvar.name, envvar.value.to_str) unless dry_run?
             end
 
             delete_envvars.each do |envvar|
@@ -47,7 +47,7 @@ module Circleci
 
             update_envvars.each do |envvar|
               puts "  ~ update #{envvar.name}=#{envvar.value}".light_blue
-              api.add_envvar(proj.id, envvar.name, envvar.value.raw) unless dry_run?
+              api.add_envvar(proj.id, envvar.name, envvar.value.to_str) unless dry_run?
             end
 
             unless dry_run?

--- a/lib/circleci/env/vault.rb
+++ b/lib/circleci/env/vault.rb
@@ -1,25 +1,17 @@
 require "ansible/vault"
 
-class String
-  def raw; self end
-end
-
 module Circleci
   module Env
     module Vault
       SECRET_DIR = "secret"
 
-      class SecretString
-        def initialize(str)
-          @str = str
-        end
-
-        def raw
-          @str
-        end
-
+      class SecretString < String
         def to_s
-          "xxxx#{@str[-1]}"
+          "xxxx#{self[-1]}"
+        end
+
+        def to_str
+          self
         end
       end
 

--- a/spec/circleci/vault_spec.rb
+++ b/spec/circleci/vault_spec.rb
@@ -1,0 +1,48 @@
+describe Circleci::Env::Vault do
+  describe Circleci::Env::Vault::SecretString do
+    before do
+      @str = Circleci::Env::Vault::SecretString.new("this is secret")
+    end
+
+    describe "#to_s" do
+      it "should return masked value" do
+        expect(@str.to_s).to eq "xxxxt"
+      end
+    end
+
+    describe "#to_str" do
+      it "should return raw value" do
+        expect(@str.to_str).to eq "this is secret"
+      end
+    end
+  end
+
+  context "module methods" do
+    include Circleci::Env::Vault
+
+    describe "#secret_file_path" do
+      it "should return secret file path" do
+        expect(secret_file_path("name")).to eq "secret/name.vault"
+      end
+    end
+
+    describe "#read" do
+      it "should call Ansible::Valut.read()" do
+        name = "name"
+        password = "password"
+        allow(Ansible::Vault).to receive(:read).with(path: secret_file_path(name), password: password)
+        read(name, password)
+      end
+    end
+
+    describe "#write" do
+      it "should call Ansible::Valut.write()" do
+        name = "name"
+        value = "value"
+        password = "password"
+        allow(Ansible::Vault).to receive(:write).with(path: secret_file_path(name), plaintext: value, password: password)
+        write(name, value, password)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Extend `String` class to add new `raw` method is not good way.
Instead of that, I change implementation of `Vault::SecretString` as subclass of `String` and override `to_str` method.