### PR TITLE
Install the gem via clone and build/install it locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,22 @@
 
 ## Installation
 
-Add this line to your application's Gemfile:
+First, download the source:
 
 ```ruby
-gem 'circleci-env'
+$ git clone git@github.com:quipper/circleci-env.git
 ```
 
-And then execute:
+Build the gem:
 
 ```sh
-$ bundle
+$ cd circleci-env && gem build circleci-env.gemspec
 ```
 
-Or install it yourself as:
+Install it (the filename/version may vary)
 
 ```sh
-$ gem install circleci-env
+$ gem install circleci-env-0.2.0.gem
 ```
 
 ## Supported Settings


### PR DESCRIPTION
Reasons:
- `circleci-env` is a private gem which we use in quipper.
- It's not published in rubygems https://rubygems.org/search?utf8=%E2%9C%93&query=circleci-env
- We cannot use `gem install circleci-env` because it's not a published gem
- We need a way to use it independently (without [`quipper/circleci`](https://github.com/quipper/circleci) dependency)

![screen shot 2017-10-26 at 5 31 54 pm](https://user-images.githubusercontent.com/2811885/32045738-9b0bd616-ba73-11e7-8661-b7468ecd11f0.png)

Please review @quipper/sre 