### PR TITLE
Bump faraday gem to the latest version

### DIFF
--- a/circleci-env.gemspec
+++ b/circleci-env.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ansible-vault", "~> 0.2.1"
   spec.add_runtime_dependency "commander", "~> 4.4.3"
   spec.add_runtime_dependency "colorize", "~> 0.8.1"
-  spec.add_runtime_dependency "faraday", "~> 0.10.1"
-  spec.add_runtime_dependency "faraday_middleware", "~> 0.10.1"
+  spec.add_runtime_dependency "faraday", "~> 2.6.0"
+  spec.add_runtime_dependency "faraday_middleware", "~> 1.2.0"
   spec.add_runtime_dependency "sshkey", "~> 1.9.0"
 
   spec.add_development_dependency "bundler", "~> 1.13"

--- a/circleci-env.gemspec
+++ b/circleci-env.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ansible-vault", "~> 0.2.1"
   spec.add_runtime_dependency "commander", "~> 4.4.3"
   spec.add_runtime_dependency "colorize", "~> 0.8.1"
-  spec.add_runtime_dependency "faraday", "~> 2.6.0"
+  spec.add_runtime_dependency "faraday", "~> 1.10.1"
   spec.add_runtime_dependency "faraday_middleware", "~> 1.2.0"
   spec.add_runtime_dependency "sshkey", "~> 1.9.0"
 

--- a/lib/circleci/env/version.rb
+++ b/lib/circleci/env/version.rb
@@ -1,5 +1,5 @@
 module Circleci
   module Env
-    VERSION = "0.3.1"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
To fix the error: https://github.com/quipper/circleci/pull/567#issuecomment-1271288151

```
ArgumentError: tried to create Proc object without a block
  /home/circleci/project/vendor/bundle/ruby/3.1.0/gems/faraday-0.10.1/lib/faraday/options.rb:153:in `new'
```

seems to be needed to update faraday